### PR TITLE
app/firefox: bump to version 106.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "firefox"
-version = "105.0.1"
+version = "106.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/app/firefox/Cargo.toml
+++ b/app/firefox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefox"
-version = "105.0.1"
+version = "106.0.1"
 authors = ["Wayne Warren <wayne.warren.s@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Bumped version and confirmed it works by running `./target/debug/firefox run`:
![firefoxWorks](https://user-images.githubusercontent.com/7146319/198739720-de173c61-b9e6-4122-8c90-66703121b8e8.png)
